### PR TITLE
Detailed message for "rule unreachable" error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PikaParser"
 uuid = "3bbf5609-3e7b-44cd-8549-7c69f321e792"
 authors = ["The developers of PikaParser.jl"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -42,27 +42,13 @@ function make_grammar(
         end
     end
 
-    # if some grammar rules is unreachable from starts, throw an error with detailed information about what rules are unreachable
-    if any(opened .<= 0) # the following code executes only when throwing error, so it doesn't affect runtime efficiency
-        reached::Set = Set(starts)
-        last_n_reached::Integer = 0
-        # uses BFS to compute what rules are reached
-        while length(reached) > last_n_reached
-            last_n_reached = length(reached)
-            for reached_term in reached
-                for child in child_clauses(rules_dict[reached_term])
-                    if child ∉ reached
-                        push!(reached, child)
-                    end
-                end
-            end
-        end
-        # throw the error with detailed information about what rules are unreachable
+    # At this point, all rules should be opened at least once. If some grammar
+    # rules are unreachable from the starts, report them explicitly in the
+    # error message to ease the debugging.
+    if !all(opened .> 0)
+        unreachable_names = map(Base.first, rules)[opened.==0]
         error(
-            "The following grammar rules are unreachable from starts:\n" * join(
-                setdiff(keys(rules_dict), reached) .|> repr,
-                "\n"
-            )
+            "grammar rules not reachable from starts: $(join(repr.(unreachable_names), ", "))",
         )
     end
 

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -42,7 +42,29 @@ function make_grammar(
         end
     end
 
-    all(opened .> 0) || error("some grammar rules not reachable from starts")
+    # if some grammar rules is unreachable from starts, throw an error with detailed information about what rules are unreachable
+    if any(opened .<= 0) # the following code executes only when throwing error, so it doesn't affect runtime efficiency
+        reached::Set = Set(starts)
+        last_n_reached::Integer = 0
+        # uses BFS to compute what rules are reached
+        while length(reached) > last_n_reached
+            last_n_reached = length(reached)
+            for reached_term in reached
+                for child in child_clauses(rules_dict[reached_term])
+                    if child ∉ reached
+                        push!(reached, child)
+                    end
+                end
+            end
+        end
+        # throw the error with detailed information about what rules are unreachable
+        error(
+            "The following grammar rules are unreachable from starts:\n" * join(
+                setdiff(keys(rules_dict), reached) .|> repr,
+                "\n"
+            )
+        )
+    end
 
     reordered = rules[topo_order]
 


### PR DESCRIPTION
# Introduction

For a syntax-intensive formal language, it may require many grammar rules to establish a relatively complete parser.

During the construction of these "complex formal languages," some redundant rules are inevitable in the top-down process. These rules are necessary for the grammar but temporarily not used.

However, when it comes to minimizing testing of grammar rules, users may have written a large number of rules before testing. As mentioned above, some of these rules may not be used temporarily (but will be used in the complete grammar rules). 
If the grammar is tested while "constructing the grammar where associations are not yet fully established," the current PikaParser throws the following exception:

```
ERROR: LoadError: some grammar rules not reachable from starts
Stacktrace:
 [1] error(s::String)
   @ Base .\error.jl:35
 [2] make_grammar(starts::Vector{Symbol}, rules_dict::Dict{Symbol, PikaParser.Clause{Symbol, Char}})
   @ PikaParser [...]\PikaParser\[...]\src\grammar.jl:45
```

Before encountering this exception, users may have added multiple grammar rules. Therefore, identifying "which grammar rules are unreachable" is sometimes not an easy task. Additionally, even with variable tracing enabled, the error message does not provide any clues.

The changes made in this pull request aim to provide information about "which grammar rules are unreachable" when the "unreachable rule error" occurs (even though this may affect program performance). This way, users can write grammar more effectively by placing the "temporarily unused grammar" elsewhere.

# Minimum Working Example

Background: I need to add a ":uint" rule to improve the parsing speed of unsigned integers in the JSON parser. Now, I need to test if ":uint" can correctly recognize unsigned integers before adding it to the ":json" rule.

The example rule dictionary is modifyed from JSON parser, just adds a `:uint` rule that is not easy to find:
```julia
rules = Dict(
    :t => P.tokens("true"),
    :f => P.tokens("false"),
    :null => P.tokens("null"),
    :digit => P.satisfy(isdigit),
    :number => P.seq(
        P.first(P.token('-'), P.epsilon),
        P.some(:digit),
        P.first(P.seq(P.token('.'), P.many(:digit)), P.epsilon),
    ),
    :uint => P.some(:digit),
    :quote => P.token('"'),
    :esc => P.token('\\'),
    :string => P.seq(:quote, :instrings => P.many(:instring), :quote),
    :instring => P.first(
        :escaped => P.seq(:esc, P.first(:esc, :quote)),
        :notescaped => P.satisfy(x -> x != '"' && x != '\\'),
    ),
    :array => P.seq(
        P.token('['), P.first(:inarray, P.epsilon), P.token(']')
    ),
    :sep => P.token(','),
    :inarray => P.tie(
        P.seq(
            P.seq(:json), 
            P.many(
                :separray => P.seq(:sep, :json)
            )
        )
    ),
    :obj => P.seq(P.token('{'), P.first(:inobj, P.epsilon), P.token('}')),
    :pair => P.seq(:string, P.token(':'), :json),
    :inobj => P.tie(P.seq(P.seq(:pair), P.many(:sepobj => P.seq(:sep, :pair)))),
    :json => P.first(:obj, :array, :string, :number, :t, :f, :null),
)
```

And then run code:
```julia
using PikaParser as P
g = P.make_grammar([:json], P.flatten(rules, Char))
```

This rule dictionary, when parsed by PikaParser, causes the same error as described earlier, regardless of which "unreachable rules" are. 

# Solution

I added a piece of code to the error, used the BFS algorithm to search for "reachable rules", and then used "setdiff" to get "unreachable rules" and insert it into the error message.    (Note: Users may have used `flatten` or other ways to preprocess the rule dictionary before calling `make_grammar`, so the "unreachable rules" in the error message may not be the rules in the original "rule dictionary")

The core algorithm is as follows:
```julia
reached::Set = Set(starts)
last_n_reached::Integer = 0
# uses BFS to compute what rules are reached
while length(reached) > last_n_reached
    last_n_reached = length(reached)
    for reached_term in reached
        for child in child_clauses(rules_dict[reached_term])
            if child ∉ reached
                push!(reached, child)
            end
        end
    end
end
```

So we can provide more detailed error information:
```julia
# throw the error with detailed information about what rules are unreachable
error(
    "The following grammar rules are unreachable from starts:\n" * join(
        setdiff(keys(rules_dict), reached) .|> repr,
        "\n"
    )
)
```

While it's not the final solution, hopefully it will make the development experience better for others who write parsers in PikaParser :)